### PR TITLE
Adds support for a top-level NSWindow

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This library is designed for use with [skpm](https://github.com/skpm/skpm).
    npm install --save sketch-nibui
    ```
 
-2. Create an XIB file in Interface Builder with a single top-level `NSView`.
+2. Create an XIB file in Interface Builder with a single top-level `NSView` or `NSWindow`.
 
 3. Convert the XIB to a NIB and place it in your plugin's `assets` directory:
    ```
@@ -41,6 +41,10 @@ You'll likely want to access subviews under your top-level `NSView`. To do that:
    to an ID like `myView`.
 
 2. Access it using `nib.views.myView`
+
+### Using windows
+
+If your XIB has an `NSWindow` as its top-level view, you can access it with `nib.rootWindow` and its content view with `nib.rootView`. Access subviews using `nib.views.myView` like when the top-level view is an `NSView`.
 
 ## Handling events
 

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ class NibUI {
     // populate view IDs
     this.views = {};
     if (this.rootWindow != null) {
-      this.rootView = this.rootWindow.contentView()
+      this.rootView = this.rootWindow.contentView();
     }
     walkViewTree(this.rootView, view => {
       let id = String(view.identifier());

--- a/index.js
+++ b/index.js
@@ -48,6 +48,9 @@ class NibUI {
         if (obj.className().endsWith('View')) {
           this.rootView = obj;
           break;
+        } else if (obj.className().endsWith('Window')) {
+          this.rootWindow = obj;
+          break;
         }
       }
     } else {
@@ -56,6 +59,9 @@ class NibUI {
 
     // populate view IDs
     this.views = {};
+    if (this.rootWindow != null) {
+      this.rootView = this.rootWindow.contentView()
+    }
     walkViewTree(this.rootView, view => {
       let id = String(view.identifier());
       if (id && !id.startsWith('_')) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sketch-nibui",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A library for Sketch plugins that lets you load UI views from NIB files built with Interface Builder. Designed for use with skpm.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hello! I added support for a top-level `NSWindow` object to be able to show a window sheet without wrapping a view in a window manually, and thought it could be a helpful add upstream.

I know [skpm's nib-loader](https://github.com/skpm/nib-loader) is on the way, but could be nice to have until then!